### PR TITLE
Minor improvements to reflection class

### DIFF
--- a/licorne/reflection.py
+++ b/licorne/reflection.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 import numpy as np
 
-class Mat:
+class Mat(object):
     def __init__(self, size):
         self.oneone = np.zeros(size, dtype=np.complex128)
         self.onetwo = np.zeros(size, dtype=np.complex128)
@@ -11,7 +11,7 @@ class Mat:
     def __len__(self):
         return len(self.oneone)
 
-class SMat:
+class SMat(object):
     def __init__(self, size):
         self.M11 = Mat(size)
         self.M12 = Mat(size)
@@ -227,7 +227,6 @@ def spin_av(R, n1, n2, pol_eff, an_eff):
 def resolut(RR, q, dq):
     N = len(q)
     Nm1 = N - 1
-    denominator = np.zeros(N)
     RRr = np.zeros(N)
     pi_s = np.sqrt(2.0 * np.pi)
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,5 +1,6 @@
 from licorne import reflection
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 import os
 import unittest
 
@@ -37,17 +38,9 @@ class TestReflectionClass(unittest.TestCase):
 
         paramfile.close()
 
-        q = []
-        dq = []
-        with open(os.path.join(os.path.dirname(__file__),'data/refl_q_dq.dat'),'r') as qfile:
-            for line in qfile:
-                tmp = [float(value) for value in line.split()]
-                q.append(tmp[0])
-                dq.append(tmp[1])
-        qfile.close()
-        q = np.array(q)
-        dq = np.array(dq)
+        q, dq = np.loadtxt(os.path.join(os.path.dirname(__file__),'data/refl_q_dq.dat'),unpack=True)
         inc_moment = q / 2.0
+
         pol_eff = np.ones(len(q), dtype=np.complex128)
         an_eff = np.ones(len(q), dtype=np.complex128)
 
@@ -57,15 +50,8 @@ class TestReflectionClass(unittest.TestCase):
             RRr = reflection.resolut(RR, q, dq)
             RRr = RRr * norm_factor[k] + background
 
-            reference_values = []
-            with open(os.path.join(os.path.dirname(__file__),'data/refl'+str(k+1)+'.dat'), 'r') as reflfile:
-                for line in reflfile:
-                    reference_values.append(float(line))
-            reflfile.close()
-
-            self.assertEqual(len(reference_values),len(RRr))
-            for value, reference in zip(RRr, reference_values):
-                self.assertAlmostEqual(value,reference)
+            reference_values = np.loadtxt(os.path.join(os.path.dirname(__file__),'data/refl'+str(k+1)+'.dat'), unpack=True)
+            assert_array_almost_equal(reference_values, RRr)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_almost_equal
 import os
 import unittest
 
-class Layer:
+class Layer(object):
     pass
 
 class TestReflectionClass(unittest.TestCase):


### PR DESCRIPTION
This fixes pylint warnings in reflection and uses `np.loadtxt` and `numpy.testing.assert_array_almost_equal` to simplify the testing code. 