### PR TITLE
Migrate from precise to trusty builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
+
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
   - "3.4"
   - "3.6"
+
+dist: trusty
+
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the


### PR DESCRIPTION
Ubuntu 12.04 has reached EOL and travis-ci is moving in Q3 to use 14.04 as the stable image. Let's try switching and see if everything still works. 